### PR TITLE
Changed publisher name to "dracula-theme" as is the publisher's id on…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "engines": {
         "vscode": "*"
     },
-    "publisher": "Dracula Theme",
+    "publisher": "dracula-theme",
     "license": "MIT",
     "bugs": {
         "url": "https://github.com/dracula/visual-studio-code/issues"


### PR DESCRIPTION
Changed publisher name to "dracula-theme" as is the publisher's id on VS Marketplace. Couldn't use just "Dracula Theme", becuase VS Marketplace doesn't support human-friendly names as ID's.
![zrzut ekranu 2016-05-19 20 50 28](https://cloud.githubusercontent.com/assets/15522312/15405781/b0b81758-1e03-11e6-8feb-cf64e0bb3965.png)
