### PR TITLE
add markdown syntax

### DIFF
--- a/themes/Dracula.tmTheme
+++ b/themes/Dracula.tmTheme
@@ -568,6 +568,17 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>Markdown: Horizontal Rule</string>
+			<key>scope</key>
+			<string>meta.separator.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#6272a4</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>Markdown: Italics</string>
 			<key>scope</key>
 			<string>markup.italic.markdown</string>

--- a/themes/Dracula.tmTheme
+++ b/themes/Dracula.tmTheme
@@ -522,6 +522,120 @@
 				<string>#ffb86c</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Heading</string>
+			<key>scope</key>
+			<string>markup.heading.${1/(#)(#)?(#)?(#)?(#)?(#)?/${6:?6:${5:?5:${4:?4:${3:?3:${2:?2:1}}}}}/}.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bd93f9</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Links</string>
+			<key>scope</key>
+			<string>markup.underline.link.markdown,markup.underline.link.image.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#8be9fd</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Link Titles / Descriptions</string>
+			<key>scope</key>
+			<string>string.other.link.description.markdown,string.other.link.title.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff79c6</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Blockquotes</string>
+			<key>scope</key>
+			<string>markup.quote.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#6272a4</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Italics</string>
+			<key>scope</key>
+			<string>markup.italic.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f1fa8c</string>
+				<key>fontStyle</key>
+				<string>italic</key>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Bold</string>
+			<key>scope</key>
+			<string>markup.bold.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ffb86c</string>
+				<key>fontStyle</key>
+				<string>bold</key>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Lists</string>
+			<key>scope</key>
+			<string>beginning.punctuation.definition.list.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#8be9fd</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Inline Code</string>
+			<key>scope</key>
+			<string>markup.inline.raw.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#50fa7b</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Code Block Fence</string>
+			<key>scope</key>
+			<string>punctuation.definition.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#50fa7b</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Code Block Language</string>
+			<key>scope</key>
+			<string>fenced_code.block.language</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ff79c6</string>
+			</dict>
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>83091B89-765E-4F0D-9275-0EC6CB084126</string>


### PR DESCRIPTION
This PR adds syntax highlighting for markdown files.

### Before
![image](https://cloud.githubusercontent.com/assets/5240018/22996086/801dd402-f39b-11e6-858b-d29ea2178171.png)

### After
![image](https://cloud.githubusercontent.com/assets/5240018/22996075/742e5e8c-f39b-11e6-997e-8b3455631b44.png)

The scheme was copied directly from the `atom-dracula` package.

Closes #6.

