### PR TITLE
Add ocaml type highlighting

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -780,6 +780,7 @@ tokenColors:
     - storage.type.objc
     - storage.type.php
     - storage.type.haskell
+    - storage.type.ocaml
     settings:
       fontStyle: italic
       foreground: *CYAN


### PR DESCRIPTION
Since dracula changed `Types` from `storage.type` to explicit list of languages, it's unusable under ocaml language because all types are highlighted same as keyword - both are red. So I added `storage.type.ocaml` to the list.

<img width="408" alt="2017-06-15 5 38 16" src="https://user-images.githubusercontent.com/540298/27175458-db57b0e0-51f1-11e7-84cf-8d43cc0981bf.png">
<img width="409" alt="2017-06-15 5 40 56" src="https://user-images.githubusercontent.com/540298/27175471-e53dbf0a-51f1-11e7-88b3-943d46ab4a96.png">

