### PR TITLE
Add support for elixir's underscored variables

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -528,6 +528,8 @@ tokenColors:
   - name: Comments
     scope:
     - comment
+    - unused.comment
+    - wildcard.comment
     settings:
       foreground: *COMMENT
 


### PR DESCRIPTION
This PR adds support for Elixir's [underscored variables](https://hexdocs.pm/elixir/master/naming-conventions.html#underscore-_foo), which are often treated as comments since they are unused.

<img width="541" alt="screen shot 2017-09-17 at 10 13 36 am" src="https://user-images.githubusercontent.com/89570/30521645-e8ad1b5c-9b90-11e7-8357-6e503baaace7.png">

<img width="539" alt="screen shot 2017-09-17 at 10 13 20 am" src="https://user-images.githubusercontent.com/89570/30521647-ecd2f38c-9b90-11e7-9397-8ccbfedbb22d.png">
