### PR TITLE
Change the Codelens color from orange to the comment color - being much easier on the eyes and less distracting

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -185,7 +185,7 @@ colors:
   editorIndentGuide.background:                                                 # Color of the editor indentation guides
   editorRuler.foreground:                                                       # Color of the editor rulers
 
-  editorCodeLens.foreground: *ORANGE                                            # Foreground color of an editor CodeLens
+  editorCodeLens.foreground: *COMMENT                                            # Foreground color of an editor CodeLens
 
   # NOTE: These are not set because they tend to be highly contested from
   # person to person. Thus, setting these is probably better suited


### PR DESCRIPTION
Recently I've tried using codelens and with this theme I've noticed I find the orange currently used for codelens to be pretty bright and distracting, so I've tried changing it to a much less distracting but still readable color (I've reused the comment color for this - I think a codelens line is close enough to a comment to justify it, and it's a lot easier on the eyes)

Anyway, here's the before:

![before](https://i.imgur.com/N1dTtLs.png)

And after:

![After](https://i.imgur.com/IWUBcqp.png)

I think this is much less distracting, and also matches what other themes including the standard Dark theme do:

![Dark+ codelens](https://i.imgur.com/I3U6VGd.png)

If orange was picked for a reason or if there's some support for keeping the orange then obviously I can understand that and I'll just use my changes locally, but I think almost every theme uses a much more subtle color for codelens
