### PR TITLE
Enable color for active indent guide, also adjust whitespace + inactive indent color

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "theme-dracula",
-    "version": "2.5.2",
+    "version": "2.9.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -39,7 +39,7 @@ dracula:
   other:
     - &COMMENT       '#6272A4'
     - &LineHighlight '#44475A75'
-    - &Whitespace    '#44475AC8'
+    - &NonText       '#424450'
     - &WHITE         '#FFFFFF'
     - &TAB_DROP_BG   '#44475A70'
     # UI Variants
@@ -188,8 +188,8 @@ colors:
   editorLink.activeForeground: *CYAN                                            # Color of active links
   editor.rangeHighlightBackground: !alpha [ *PURPLE, 15 ]                       # Background color of highlighted ranges, like by Quick Open and Find features
 
-  editorWhitespace.foreground: *Whitespace                                      # Color of whitespace characters in the editor
-  editorIndentGuide.background: *Whitespace                                     # Color of the editor indentation guides
+  editorWhitespace.foreground: *NonText                                         # Color of whitespace characters in the editor
+  editorIndentGuide.background: *NonText                                        # Color of the editor indentation guides
   editorIndentGuide.activeBackground: !alpha [ *WHITE, 45]                      # Color of the active indentation guide
   editorRuler.foreground:                                                       # Color of the editor rulers
 

--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -39,6 +39,7 @@ dracula:
   other:
     - &COMMENT       '#6272A4'
     - &LineHighlight '#44475A75'
+    - &Whitespace    '#44475AC8'
     - &WHITE         '#FFFFFF'
     - &TAB_DROP_BG   '#44475A70'
     # UI Variants
@@ -187,11 +188,12 @@ colors:
   editorLink.activeForeground: *CYAN                                            # Color of active links
   editor.rangeHighlightBackground: !alpha [ *PURPLE, 15 ]                       # Background color of highlighted ranges, like by Quick Open and Find features
 
-  editorWhitespace.foreground:                                                  # Color of whitespace characters in the editor
-  editorIndentGuide.background:                                                 # Color of the editor indentation guides
+  editorWhitespace.foreground: *Whitespace                                      # Color of whitespace characters in the editor
+  editorIndentGuide.background: *Whitespace                                     # Color of the editor indentation guides
+  editorIndentGuide.activeBackground: !alpha [ *WHITE, 45]                      # Color of the active indentation guide
   editorRuler.foreground:                                                       # Color of the editor rulers
 
-  editorCodeLens.foreground: *COMMENT                                            # Foreground color of an editor CodeLens
+  editorCodeLens.foreground: *COMMENT                                           # Foreground color of an editor CodeLens
 
   # NOTE: These are not set because they tend to be highly contested from
   # person to person. Thus, setting these is probably better suited


### PR DESCRIPTION
<!--

If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

-->
This PR will enable (there doesn't appear to be an editor setting for it, just a color) the [new active indent guide color](https://code.visualstudio.com/updates/v1_23#_highlighted-indent-guides)

While I was there I brought the whitespace & now 'inactive' indent guide colors just a little bluer towards the dracula theme, as they didn't have a color before - if this isn't liked/desired I can make a new PR for just the active indent color, but it's not a drastic change and I think it fits in with the theme a little better than how it was before, where it was a little too grey-ish

Before  w/ whitespace ![before and whitespace](https://i.imgur.com/9RMqDtg.png)

**After** w/ whitespace ![after and whitespace](https://i.imgur.com/pVAcrjT.png)

Before w/o whitespace ![before](https://i.imgur.com/jDD2coW.png)

**After** w/o whitespace ![after](https://i.imgur.com/blsjuTs.png)

Will close #73 

(edited images after new commit)