### PR TITLE
fix editorRuler.foreground

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -193,7 +193,7 @@ colors:
   editorWhitespace.foreground: *NonText                                         # Color of whitespace characters in the editor
   editorIndentGuide.background: *NonText                                        # Color of the editor indentation guides
   editorIndentGuide.activeBackground: !alpha [ *WHITE, 45]                      # Color of the active indentation guide
-  editorRuler.foreground:                                                       # Color of the editor rulers
+  editorRuler.foreground: *NonText                                              # Color of the editor rulers
 
   editorCodeLens.foreground: *COMMENT                                           # Foreground color of an editor CodeLens
 


### PR DESCRIPTION
Hello,

Currently, "editor.rulers" setting in VS Code displays rulers with the default brownish color.

This simply changes rulers to be the same color as indentation guides. See comparison below (new above, current below).

![editorrulerforegroundchange](https://user-images.githubusercontent.com/31779292/42507782-a73c97a2-8446-11e8-9ecd-568b1e802d6e.png)
