### PR TITLE
List filter widget colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "theme-dracula",
-    "version": "2.14.1",
+    "version": "2.15.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -16,7 +16,7 @@ const get = url =>
     });
 
 const THEME_COLOR_REFERENCE_URL =
-    'https://code.visualstudio.com/docs/getstarted/theme-color-reference';
+    'https://code.visualstudio.com/api/references/theme-color';
 
 const NOT_THEME_KEYS = [
     'workbench.colorCustomizations',

--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -377,8 +377,8 @@ colors:
   # Misc
   menu.separatorBackground:                                                     # Color of a separator menu item in menus
 
-  listFilterWidget.background: *BG                                              # Background color of the type filter widget in lists and trees.
-  listFilterWidget.outline: *BGDarker                                           # Outline color of the type filter widget in lists and trees.
+  listFilterWidget.background: *BGLight                                              # Background color of the type filter widget in lists and trees.
+  listFilterWidget.outline: *BGLighter                                           # Outline color of the type filter widget in lists and trees.
   listFilterWidget.noMatchesOutline: *RED                                       # Outline color of the type filter widget in lists and trees, when there are no matches.
 
 # Syntaxes

--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -377,6 +377,10 @@ colors:
   # Misc
   menu.separatorBackground:                                                     # Color of a separator menu item in menus
 
+  listFilterWidget.background: *BG                                              # Background color of the type filter widget in lists and trees.
+  listFilterWidget.outline: *BGDarker                                           # Outline color of the type filter widget in lists and trees.
+  listFilterWidget.noMatchesOutline: *RED                                       # Outline color of the type filter widget in lists and trees, when there are no matches.
+
 # Syntaxes
 tokenColors:
 


### PR DESCRIPTION
This add coloring to the new List Filter Widget feature available in VS Code 1.31.0

# Before
![image](https://user-images.githubusercontent.com/11427028/52372226-809bfc00-2a4f-11e9-9d32-86c0c52d6adb.png)
![image](https://user-images.githubusercontent.com/11427028/52372232-872a7380-2a4f-11e9-92f7-8cd667839ba8.png)

# After
![image](https://user-images.githubusercontent.com/11427028/52373047-a7f3c880-2a51-11e9-84a6-a3326b7b7766.png)
![image](https://user-images.githubusercontent.com/11427028/52373065-af1ad680-2a51-11e9-82e8-9d0ebed0a230.png)

