### PR TITLE
adjust jsdoc highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.17.0
+
+### Minor
+
+- Adjust JSDoc-style comments to align with specification.
+
 ## 2.16.0
 
 ### Minor

--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -570,8 +570,8 @@ tokenColors:
     - keyword.other.this
     - variable.language
     - variable.language punctuation.definition.variable.php # the "$" symbol in $this
-    - variable.other.readwrite.instance.ruby       # ruby's "@" instance symbol
-    - variable.parameter.function.language.special # Special words as parameters
+    - variable.other.readwrite.instance.ruby                # ruby's "@" instance symbol
+    - variable.parameter.function.language.special          # Special words as parameters
     settings:
       foreground: *PURPLE
       fontStyle: italic
@@ -596,14 +596,26 @@ tokenColors:
     settings:
       foreground: *COMMENT
 
-  - name: JSDoc-style comment keywords/classes
+  - name: JSDoc-style keywords
     scope:
     - comment keyword.codetag.notation
     - comment.block.documentation keyword
     - comment.block.documentation storage.type.class
     settings:
+      foreground: *PINK
+
+  - name: JSDoc-style types
+    scope:
+    - comment.block.documentation entity.name.type
+    settings:
       foreground: *CYAN
       fontStyle: italic
+
+  - name: JSDoc-style type brackets
+    scope:
+    - comment.block.documentation entity.name.type punctuation.definition.bracket
+    settings:
+      foreground: *CYAN
 
   - name: JSDoc-style comment parameters
     scope:


### PR DESCRIPTION
This PR adjusts JSDoc highlights so that they're more meaningful.

I also adjusted the master spec for this (https://dsifford.github.io/dracula-spec/).

Let me know if you have any questions.

Ping: @DanielRamosAcosta

(PS: the new debugging extension thing doesn't work at all for me. So I couldn't actually test this.)