### PR TITLE
Colorize Python docstrings as comments

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -978,6 +978,15 @@ tokenColors:
     settings:
       foreground: *TEMP_PROPERTY_QUOTES
 
+  - name: Docstrings
+    scope:
+    - string.quoted.docstring.multi
+    - string.quoted.docstring.multi.python punctuation.definition.string.begin
+    - string.quoted.docstring.multi.python punctuation.definition.string.end
+    - string.quoted.docstring.multi.python constant.character.escape
+    settings:
+      foreground: *COMMENT
+
 # =============================================================================
 # Variables
 # =============================================================================


### PR DESCRIPTION
When using the theme with Python code, [docstrings](https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring) get colorized same as regular literal strings (`YELLOW`), which could make it harder to distinguish. In addition, special characters inside docstrings (`\b`) get colorized as `PINK`, different from the rest of the docstring.

**BEFORE**:
<img width="590" alt="Screen Shot 2019-03-17 at 14 18 51" src="https://user-images.githubusercontent.com/6091865/54485808-e2f3e200-48c2-11e9-995f-fd7877b4c9db.png">

This PR colorizes both one-line and multi-line docstrings with the `COMMENT` color, since IMHO they are more for code documentation rather than literal strings. This includes special characters (`\b`) inside the docstring.

**AFTER**:
<img width="566" alt="Screen Shot 2019-03-17 at 14 30 33" src="https://user-images.githubusercontent.com/6091865/54485817-15054400-48c3-11e9-9433-4269b6e9ec9b.png">

