### PR TITLE
Update steps in contribution guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 1. Fork and clone this repo. `git clone https://github.com/<YOUR-USERNAME>/visual-studio-code`
 2. Create a branch for your changes. `git checkout -b my-new-feature`
-3. Install dependencies. `yarn`
-4. Attach your clone to visual studio code. `yarn attach`
+3. Install dependencies. `npm install`
+4. Open the *visual-studio-code* folder in vscode.
 5. Hack away.
-6. Build and examine your changes. `yarn build` (then refresh vscode and inspect your changes)
+6. Build and examine your changes in an Extension Development Host.
+    * Debug > Start Debugging or use F5 as a shortcut
 7. Commit and push your changes.
-8. Eject the repo from vscode. `yarn eject`
-9. Submit a PR for discussion, keeping in mind that not all suggestions can be accepted.
+8. Submit a PR for discussion, keeping in mind that not all suggestions can be accepted.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,7 @@
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
+      "preLaunchTask": "npm: build",
       "args": [
           "--extensionDevelopmentPath=${workspaceFolder}"
       ]


### PR DESCRIPTION
I encountered some issues following the [contributing guidelines](https://github.com/dracula/visual-studio-code/blob/master/.github/CONTRIBUTING.md) during creation of PR #102. I think some steps aren't anymore applicable?  

1) `yarn` is warning that there are multiple package managers.
<img width="718" alt="Screen Shot 2019-03-17 at 15 12 57" src="https://user-images.githubusercontent.com/6091865/54486280-66183680-48c9-11e9-8c68-58aa758c9067.png">

I propose to change step 3. to `npm install` (because I saw `npm run build` in package.json).

2) `yarn attach` and `yarn eject` are not valid commands.
<img width="605" alt="Screen Shot 2019-03-17 at 15 20 29" src="https://user-images.githubusercontent.com/6091865/54486289-8b0ca980-48c9-11e9-9d53-722947914ba6.png">
<img width="610" alt="Screen Shot 2019-03-17 at 15 21 04" src="https://user-images.githubusercontent.com/6091865/54486290-8cd66d00-48c9-11e9-9479-5eae27c6bca4.png">

I propose to change step 4. to open the cloned _visual-studio-code_ folder in vscode.  
Then use the already available _launch.json_ to run in an Extension Development Host.
Also, I propose to integrate `npm build` as a `preLaunchTask` in the launch.json.

I think there's no more need for `yarn eject`.


