### PR TITLE
Add class name color to work with Babel Javascript syntax

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -562,6 +562,7 @@ tokenColors:
   - name: User-defined class names
     scope:
     - entity.name.type.class
+    - entity.name.class
     settings:
       foreground: *CYAN
       fontStyle: normal


### PR DESCRIPTION
<!--

If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

-->

Add class name color to solve #117 

![Code_aaQYLn6dwU](https://user-images.githubusercontent.com/15521864/66693791-82554800-ecdf-11e9-9a3b-8ac1067506ad.png)

