### PR TITLE
make breadcrumb color match active tab color

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -165,7 +165,8 @@ colors:
   tab.activeBackground: *BG                                                     # Active Tab background color
   tab.activeForeground: *FG                                                     # Active Tab foreground color in an active group
   tab.border: *BGDarker                                                         # Border to separate Tabs from each other
-  tab.activeBorder: !alpha [*PINK, 80]                                          # A border drawn to the bottom of the active tab
+  tab.activeBorderTop: !alpha [*PINK, 80]                                       # A border drawn to the top of the active tab
+  tab.activeBorder:                                                             # A border drawn to the bottom of the active tab
   tab.unfocusedActiveBorder:                                                    # A border drawn to the bottom of the active tab in an editor group that is not focused
   tab.inactiveBackground: *BGDark                                               # Inactive Tab background color
   tab.inactiveForeground: *COMMENT                                              # Inactive Tab foreground color in an active group

--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -374,7 +374,7 @@ colors:
 
   # Breadcrumbs
   breadcrumb.foreground: *COMMENT                                               # Color of breadcrumb items
-  breadcrumb.background: *BGDark
+  breadcrumb.background: *BG
   breadcrumb.focusForeground: *FG                                               # Color of focused breadcrumb items
   breadcrumb.activeSelectionForeground: *FG                                     # Color of selected breadcrumb items
   breadcrumbPicker.background: *BGDarker                                        # Background color of breadcrumb item picker


### PR DESCRIPTION
If breadcrumbs are enabled, it's difficult for the eye to identify the active tab because the active tab background color doesn't match the breadcrumb background-color, thus creating the effect of differing layers. Also, the background color of the inactive tabs matches the breadcrumb background, which amplifies this false visual signal. At first sight, the active tab appears to be the only tab not on the same z-Index as the editor/breadcrumbs (should be the other way around).

 As the editor background is already the same as the active tab background, the problem only occurs when breadcrumbs are enabled (as these are between the two).  
So the easiest way to fix that is to give the breadcrumbs the same background as active tabs and the editor. That's all. This PR is really just this one change. The breadcrumb text is still readable and the different areas (tab, breadcrumbs, editor) are still visually separated by lines.

Before:  
![grafik](https://user-images.githubusercontent.com/9215743/76570931-abf4e400-64b6-11ea-9302-ce848798d1ce.png)
After:
![grafik](https://user-images.githubusercontent.com/9215743/76571076-f24a4300-64b6-11ea-94ea-b2c74c0811e5.png)
After without breadcrumbs (same as before, obviously):
![grafik](https://user-images.githubusercontent.com/9215743/76571155-1d349700-64b7-11ea-9139-b689088ae7ac.png)
