### PR TITLE
Bracket Pair Colorizer 

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -224,13 +224,13 @@ colors:
   editorBracketMatch.background:                                                # Background color behind matching brackets
   editorBracketMatch.border:                                                    # Color for matching brackets boxes
 
-  editorBracketHighlight.foreground1: *FG
-  editorBracketHighlight.foreground2: *PINK
-  editorBracketHighlight.foreground3: *CYAN
-  editorBracketHighlight.foreground4: *GREEN
-  editorBracketHighlight.foreground5: *PURPLE
-  editorBracketHighlight.foreground6: *ORANGE
-  editorBracketHighlight.unexpectedBracket.foreground: *RED
+  editorBracketHighlight.foreground1: *FG                                       # Color of first pair of brackets
+  editorBracketHighlight.foreground2: *PINK                                     # Color of second pair of brackets
+  editorBracketHighlight.foreground3: *CYAN                                     # Color of third pair of brackets
+  editorBracketHighlight.foreground4: *GREEN                                    # Color of fourth pair of brackets
+  editorBracketHighlight.foreground5: *PURPLE                                   # Color of fifth pair of brackets
+  editorBracketHighlight.foreground6: *ORANGE                                   # Color of sixth pair of brackets
+  editorBracketHighlight.unexpectedBracket.foreground: *RED                     # Color of bracket matching error
 
   editorOverviewRuler.border: *BGDarker                                         # Color of the overview ruler border
   editorOverviewRuler.findMatchForeground:

--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -224,6 +224,14 @@ colors:
   editorBracketMatch.background:                                                # Background color behind matching brackets
   editorBracketMatch.border:                                                    # Color for matching brackets boxes
 
+  editorBracketHighlight.foreground1: *FG
+  editorBracketHighlight.foreground2: *PINK
+  editorBracketHighlight.foreground3: *CYAN
+  editorBracketHighlight.foreground4: *GREEN
+  editorBracketHighlight.foreground5: *PURPLE
+  editorBracketHighlight.foreground6: *ORANGE
+  editorBracketHighlight.unexpectedBracket.foreground: *RED
+
   editorOverviewRuler.border: *BGDarker                                         # Color of the overview ruler border
   editorOverviewRuler.findMatchForeground:
   editorOverviewRuler.rangeHighlightForeground:


### PR DESCRIPTION
Adding Dracula colors for the new built in bracket pair colorizer released in VSC version 1.60.0. Using the background color for the first level as it keeps single level only brackets looking clean. Levels two through six use contrasting colors so that they can be easily distinguishable as the user gets deeper into the bracket levels.