### PR TITLE
Fixed warning and info colors

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -247,8 +247,10 @@ colors:
 
   editorError.foreground: *RED                                                  # Foreground color of error squigglies in the editor
   editorError.border:                                                           # Border color of error squigglies in the editor
-  editorWarning.foreground: *CYAN                                               # Foreground color of warning squigglies in the editor
+  editorWarning.foreground: *ORANGE                                             # Foreground color of warning squigglies in the editor
   editorWarning.border:                                                         # Border color of warning squigglies in the editor
+  editorInfo.foreground: *CYAN                                                  # Foreground color of warning squigglies in the editor
+  editorInfo.border:                                                            # Border color of warning squigglies in the editor
 
   editorGutter.background:                                                      # Background color of the editor gutter
   editorGutter.modifiedBackground: !alpha [ *CYAN, 80 ]                         # Editor gutter background color for lines that are modified


### PR DESCRIPTION
As issue #140 says, the warning color was off. On other editors, it appears as orange but on VSCode it was light blue. It's fixed now. On left is the previous version, the updated one is on the right. I also added the info color, that was missing and showed the default VSCode color (a darker blue)

![image](https://user-images.githubusercontent.com/11318350/135157016-9d50404a-0c0a-48fe-97b4-c46d5a238782.png)

Pycharm screenshot below

![image](https://user-images.githubusercontent.com/11318350/135157133-f20bb476-6586-447b-aad9-f136f9e3aaea.png)

Fixes #140 
