### PR TITLE
Fix typo on `lint.js` file

### DIFF
--- a/scripts/lint.js
+++ b/scripts/lint.js
@@ -27,7 +27,7 @@ async function scrapeThemeAvailableKeys() {
 
     if (!matches) {
         throw new Error(
-            "Couldn't find any matches with <code>...</code>, maybe docs have chaged?"
+            "Couldn't find any matches with <code>...</code>, maybe docs have changed?"
         );
     }
 


### PR DESCRIPTION
I founded a typo at the line 30.
 `chage` should be `changed`