### PR TITLE
Adds strike through font style and color

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -475,6 +475,13 @@ tokenColors:
       foreground: *YELLOW
       fontStyle: italic
 
+  - name: Markup strikethrough
+    scope:
+    - markup.strikethrough
+    settings:
+      foreground: *COMMENT
+      fontStyle: strikethrough
+
   - name: Bullets, lists (prose)
     scope:
     - beginning.punctuation.definition.list.markdown


### PR DESCRIPTION
Before:
<img width="727" alt="Screenshot 2023-03-27 at 07 04 35" src="https://user-images.githubusercontent.com/17646954/227912081-3a29f975-23a0-423b-9312-13ef5df257c8.png">

After:
<img width="727" alt="Screenshot 2023-03-27 at 07 03 29" src="https://user-images.githubusercontent.com/17646954/227912097-286526cd-9dee-45af-8dd3-c3fbfb72ccad.png">

Fixes #232 