### PR TITLE
Set color for inline chat region highlight

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -267,6 +267,7 @@ colors:
   diffEditor.insertedTextBorder:                                                # Outline color for inserted text
   diffEditor.removedTextBackground: !alpha [ *RED, 50 ]                         # Background color for removed text
   diffEditor.removedTextBorder:                                                 # Outline color for removed text
+  inlineChat.regionHighlight: *BGLight                                          # Background color for the inline chat diff region
 
   # Editor Widget Colors
   editorWidget.background: *BGDark                                              # Background color of editor widgets, such as Find/Replace


### PR DESCRIPTION
<!--

If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

-->

This PR fixes the background color of the inline chat (ie [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat)). Before, it was a very bright cyan which was hard to read and hard on the eyes. I played around with some different colors and settled on `*BGLight`, which was much easier to read, still visible, and you can still see what text is selected.

Before:
![Screenshot 2023-07-12 at 14 28 23](https://github.com/dracula/visual-studio-code/assets/14863373/08c91567-97f8-4596-a85d-f2d0cb446a38)

After:
![Screenshot 2023-07-12 at 14 28 38](https://github.com/dracula/visual-studio-code/assets/14863373/0e6a49e3-b1d0-44b4-8613-337fea78a300)
