### PR TITLE
style: ✨  Update the `gitDecoration` and `diffEditor`

### DIFF
--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -256,11 +256,13 @@ colors:
   editorGutter.deletedBackground:  !alpha [ *RED,    80 ]                       # Editor gutter background color for lines that are deleted
 
   # Explorer Colors
-  gitDecoration.modifiedResourceForeground: *CYAN
-  gitDecoration.deletedResourceForeground: *RED
-  gitDecoration.untrackedResourceForeground: *GREEN
-  gitDecoration.ignoredResourceForeground: *COMMENT
-  gitDecoration.conflictingResourceForeground: *ORANGE
+  gitDecoration.gitDecoration.addedResourceForeground: *GREEN                   # Color for added resources in git decorations
+  gitDecoration.modifiedResourceForeground: *CYAN                               # Color for modified resources in git decorations
+  gitDecoration.deletedResourceForeground: *RED                                 # Color for deleted resources in git decorations
+  gitDecoration.untrackedResourceForeground: *GREEN                             # Color for untracked resources in git decorations
+  gitDecoration.ignoredResourceForeground: *COMMENT                             # Color for ignored resources in git decorations
+  gitDecoration.conflictingResourceForeground: *ORANGE                          # Color for conflicting resources in git decorations
+  gitDecoration.submoduleResourceForeground: *COMMENT                           # Color for submodule resources in git decorations
 
   # Diff Editor Colors
   diffEditor.insertedTextBackground: !alpha [ *GREEN, 20 ]                      # Background color for inserted text

--- a/src/dracula.yml
+++ b/src/dracula.yml
@@ -200,7 +200,7 @@ colors:
 
   editor.hoverHighlightBackground: !alpha [*CYAN, 50]                           # Highlight below the word for which a hover is shown
 
-  editor.lineHighlightBackground:                                               # Background color for the highlight of line at the cursor position
+  editor.lineHighlightBackground:                                              # Background color for the highlight of line at the cursor position
   editor.lineHighlightBorder: *SELECTION                                        # Background color for the border around the line at the cursor position
 
   editorLink.activeForeground: *CYAN                                            # Color of active links
@@ -266,9 +266,20 @@ colors:
 
   # Diff Editor Colors
   diffEditor.insertedTextBackground: !alpha [ *GREEN, 20 ]                      # Background color for inserted text
-  diffEditor.insertedTextBorder:                                                # Outline color for inserted text
-  diffEditor.removedTextBackground: !alpha [ *RED, 50 ]                         # Background color for removed text
-  diffEditor.removedTextBorder:                                                 # Outline color for removed text
+  diffEditor.insertedTextBorder:     !alpha [ *GREEN, 20 ]                      # Outline color for inserted text
+  diffEditor.removedTextBackground:  !alpha [ *RED, 30 ]                        # Background color for removed text
+  diffEditor.removedTextBorder:      !alpha [ *RED, 30 ]                        # Outline color for removed text
+  diffEditor.diagonalFill: !alpha [ *RED, 40 ]                                  # Color of the diagonal fill in diff editor
+  diffEditor.insertedLineBackground: !alpha [ *GREEN, 20 ]                      # Background color for inserted lines
+  diffEditor.removedLineBackground:  !alpha [ *RED, 30 ]                        # Background color for removed lines
+  diffEditorGutter.insertedLineBackground: !alpha [ *GREEN, 20 ]                # Background color for the diff editor's inserted text overview ruler marker
+  diffEditorGutter.removedLineBackground:  !alpha [ *RED, 30 ]                  # Background color for the diff editor's removed text overview ruler marker
+  diffEditorOverview.insertedForeground: *GREEN                                 # Current overview ruler foreground for inline merge conflicts
+  diffEditorOverview.removedForeground: *RED                                    # Current overview ruler foreground for inline merge conflicts
+  diffEditor.unchangedRegionBackground: *BGLighter                              # Background color for unchanged text
+  diffEditor.unchangedRegionForeground: *COMMENT                                # Outline color for unchanged text
+  diffEditor.unchangedCodeBackground: *BGLighter                                # Background color for unchanged text
+  diffEditor.move.border: !alpha [ *RED, 30 ]                                   # Border color between the two text editors
   inlineChat.regionHighlight: *BGLight                                          # Background color for the inline chat diff region
 
   # Editor Widget Colors


### PR DESCRIPTION
<!--

If you're fixing a UI issue, make sure you take two screenshots. One that shows the actual bug and another that shows how you fixed it.

-->


<img width="1553" alt="Screenshot 2023-09-17 at 20 28 51" src="https://github.com/dracula/visual-studio-code/assets/13209783/3191893f-73d5-4309-837a-7e9758e51129">


Fixes #242 

1. Extend the options for the `gitDecoration`
2. Define all options of for `diffEditor`
3.  Scale down the alpha value for **RED**
4. Also a red mesh is added for highlighting difference in code length
